### PR TITLE
Add BDA vendor ID

### DIFF
--- a/transport/wired.c
+++ b/transport/wired.c
@@ -526,6 +526,7 @@ static const struct usb_device_id xone_wired_id_table[] = {
 	{ XONE_WIRED_VENDOR(0x0f0d) }, /* Hori */
 	{ XONE_WIRED_VENDOR(0x1532) }, /* Razer */
 	{ XONE_WIRED_VENDOR(0x24c6) }, /* PowerA */
+	{ XONE_WIRED_VENDOR(0x20d6) }, /* BDA */
 	{ XONE_WIRED_VENDOR(0x044f) }, /* Thrustmaster */
 	{ XONE_WIRED_VENDOR(0x10f5) }, /* Turtle Beach */
 	{ XONE_WIRED_VENDOR(0x2e24) }, /* Hyperkin */


### PR DESCRIPTION
This adds support for the BDA Xbox ONE Core controller, I'm not entirely sure as what this controller is sold online. The user said it would be a PowerA, but it has a different vendor id and identifies itself as BDA. The device connects and uses xone-wired, headset works as well.

![bda](https://user-images.githubusercontent.com/7719590/140658746-f750834c-615c-423f-8f1d-40b24c57f768.png)

