### PR TITLE
Add 8BitDo vendor ID

### DIFF
--- a/transport/wired.c
+++ b/transport/wired.c
@@ -531,6 +531,7 @@ static const struct usb_device_id xone_wired_id_table[] = {
 	{ XONE_WIRED_VENDOR(0x10f5) }, /* Turtle Beach */
 	{ XONE_WIRED_VENDOR(0x2e24) }, /* Hyperkin */
 	{ XONE_WIRED_VENDOR(0x3285) }, /* Nacon */
+	{ XONE_WIRED_VENDOR(0x2dc8) }, /* 8BitDo */
 	{ },
 };
 


### PR DESCRIPTION
Adding the vendor ID enables support for this 8BitDo controller.