### PR TITLE
Add SCUF vendor ID

### DIFF
--- a/transport/wired.c
+++ b/transport/wired.c
@@ -533,6 +533,7 @@ static const struct usb_device_id xone_wired_id_table[] = {
 	{ XONE_WIRED_VENDOR(0x2e24) }, /* Hyperkin */
 	{ XONE_WIRED_VENDOR(0x3285) }, /* Nacon */
 	{ XONE_WIRED_VENDOR(0x2dc8) }, /* 8BitDo */
+	{ XONE_WIRED_VENDOR(0x2e95) }, /* SCUF */
 	{ },
 };
 


### PR DESCRIPTION
Tested with [SCUF Instinct Pro](https://scufgaming.com/uk/xbox-instinct-pro-controller).

```
[  530.947911] usb 5-3.2: new full-speed USB device number 12 using xhci_hcd
[  531.027928] usb 5-3.2: device descriptor read/64, error -32
[  531.215941] usb 5-3.2: device descriptor read/64, error -32
[  531.403922] usb 5-3.2: new full-speed USB device number 13 using xhci_hcd
[  531.526704] usb 5-3.2: New USB device found, idVendor=2e95, idProduct=0504, bcdDevice= 5.09
[  531.526708] usb 5-3.2: New USB device strings: Mfr=1, Product=2, SerialNumber=3
[  531.526711] usb 5-3.2: Product: Controller
[  531.526712] usb 5-3.2: Manufacturer: Microsoft
[  531.526714] usb 5-3.2: SerialNumber: xxxxxxxxxxxxxxxxxxxxxxxxxxxx
[  531.729794] usb 5-3.2: reset full-speed USB device number 13 using xhci_hcd
[  531.860758] usbcore: registered new interface driver xone-wired
[  532.179192] input: Microsoft X-Box One pad as /devices/pci0000:40/0000:40:01.1/0000:41:00.0/0000:42:08.0/0000:48:00.1/usb5/5-3/5-3.2/5-3.2:1.0/gip0/gip0.0/input/input40
```