### PR TITLE
Rename gamepad, headset & chatpad

### DIFF
--- a/driver/chatpad.c
+++ b/driver/chatpad.c
@@ -8,7 +8,7 @@
 
 #include "common.h"
 
-#define GIP_CP_NAME "Microsoft X-Box One chatpad"
+#define GIP_CP_NAME "Microsoft Xbox Chatpad"
 
 struct gip_chatpad {
 	struct gip_client *client;

--- a/driver/gamepad.c
+++ b/driver/gamepad.c
@@ -9,7 +9,7 @@
 
 #include "common.h"
 
-#define GIP_GP_NAME "Microsoft X-Box One pad"
+#define GIP_GP_NAME "Microsoft Xbox Controller"
 
 /* product ID for the elite controller series 2 */
 #define GIP_GP_PID_ELITE2 0x0b00

--- a/driver/headset.c
+++ b/driver/headset.c
@@ -11,7 +11,7 @@
 
 #include "common.h"
 
-#define GIP_HS_NAME "Microsoft X-Box One headset"
+#define GIP_HS_NAME "Microsoft Xbox Headset"
 
 /* product ID for the chat headset */
 #define GIP_HS_PID_CHAT 0x0111


### PR DESCRIPTION
Turns e.g.:
![ms_controller_old](https://user-images.githubusercontent.com/414984/178922808-d8f75768-c5cb-4c25-bd36-efa4217aebaa.png)
into:
![ms_controller_new](https://user-images.githubusercontent.com/414984/178922853-5d4ea0c2-5c21-4f08-8b9e-9af88501049f.png)

As the driver works for both One and Series controllers and Microsoft also named both their products just `Xbox Wireless Controller` I've also removed the `One` from the string. The controllers also appear to be uppercase on both Microsoft products and also in Steam (imho it looks nicer like that in the KDE Plasma powermanagement applet and it's also written like that already in the README.md so I've adjusted the string accordingly for Heatset and Chatpad as well). Some pictures for reference:

Xbox One Controller:
![ms_controller_product](https://user-images.githubusercontent.com/414984/178923313-481f41cc-4a54-4a5c-9b7e-8f8213c41f2e.png)

Xbox Series Controller:
![ms_controller_product_series](https://user-images.githubusercontent.com/414984/178925651-89ddbe8f-a62e-41b2-9843-7b8886d9305a.png)

Name in Steam:
![ms_controller_steam](https://user-images.githubusercontent.com/414984/178923341-dd6dd8d7-eb52-4aa7-a914-a67be3f5a97c.png)
