### PR TITLE
Add "wireless-regdb" package requirement.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Any issues regarding the packaging should be reported to the respective maintain
 - DKMS
 - curl (for firmware download)
 - cabextract (for firmware extraction)
+- wireless-regdb (Needed for wireless frequency regulatory compliance.)
 
 ### Guide
 


### PR DESCRIPTION
Kernel module purposely seeks out this database. Not installed by default on some distributions, such as Arch in this case.