### PR TITLE
Add GameSir vendor ID

### DIFF
--- a/transport/wired.c
+++ b/transport/wired.c
@@ -558,6 +558,7 @@ static const struct usb_device_id xone_wired_id_table[] = {
 	{ XONE_WIRED_VENDOR(0x3285) }, /* Nacon */
 	{ XONE_WIRED_VENDOR(0x2dc8) }, /* 8BitDo */
 	{ XONE_WIRED_VENDOR(0x2e95) }, /* SCUF */
+	{ XONE_WIRED_VENDOR(0x3537) }, /* GameSir */
 	{ },
 };
 


### PR DESCRIPTION
This will add support for devices by GameSir. Tested with [GameSir G7 Wired Controller for XBOX & PC](https://www.gamesir.hk/products/gamesir-g7-wired-controller-for-xbox-pc).