### PR TITLE
Update README.md, fix download firmware instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ sudo ./install.sh --release
 4. Download the firmware for the wireless dongle:
 
 ```
-sudo xone-get-firmware.sh
+sudo chmod +x ./install/firmware.sh
+sudo ./install/firmware.sh
 ```
 
 **NOTE:** The `--skip-disclaimer` flag might be useful for scripting purposes.


### PR DESCRIPTION
I currently used your repository to get my Xbox One Controller running on Debian.
During this I found out, that the instruction for downloading the firmware seems outdated, because the listed script does not exist. Instead there is a script in the `install` directory called `firmware.sh`, but it's also missing execute rights.
So I did a quick update of `README.md`so that you can easily merge it :-)