### PR TITLE
Add Priferential vendor ID

### DIFF
--- a/transport/wired.c
+++ b/transport/wired.c
@@ -561,6 +561,7 @@ static const struct usb_device_id xone_wired_id_table[] = {
 	{ XONE_WIRED_VENDOR(0x3537) }, /* GameSir */
 	{ XONE_WIRED_VENDOR(0x11c1) }, /* ??? */
 	{ XONE_WIRED_VENDOR(0x294b) }, /* Snakebyte */
+	{ XONE_WIRED_VENDOR(0x2c16) }, /* Priferential */
 	{ },
 };
 


### PR DESCRIPTION
Add in the vendor ID from a "Microsoft" clone controller from Ali Express. The vendor ID suggests the brand is the now-defunct Priferential Accessories Ltd.

`lsusb` output for the controller:

```
Bus 001 Device 006: ID 2c16:a2b3  Controller
```