### PR TITLE
Re-Enable `pairing` Attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,20 @@ ACTION=="add", SUBSYSTEM=="leds", KERNEL=="gip*", ATTR{mode}="2", ATTR{brightnes
 Replace the wildcard (`gip*`) if you want to control the LED of a specific device.
 The modes and the maximum brightness can vary from device to device.
 
+## Pairing mode
+
+The pairing mode of the dongle can be queried via `sysfs`:
+
+```
+cat /sys/bus/usb/drivers/xone-dongle/*/pairing
+```
+
+You can enable (`1`) or disable (`0`) the pairing using the following command:
+
+```
+echo 1 | sudo tee /sys/bus/usb/drivers/xone-dongle/*/pairing
+```
+
 ## Troubleshooting
 
 Uninstall the release version and install a debug build of `xone` (see installation guide).

--- a/transport/dongle.c
+++ b/transport/dongle.c
@@ -8,6 +8,7 @@
 #include <linux/bitfield.h>
 #include <linux/version.h>
 #include <linux/usb.h>
+#include <linux/sysfs.h>
 #include <linux/ieee80211.h>
 #include <net/cfg80211.h>
 
@@ -261,6 +262,53 @@ static void xone_dongle_pairing_timeout(struct work_struct *work)
 		dev_err(dongle->mt.dev, "%s: disable pairing failed: %d\n",
 			__func__, err);
 }
+
+static ssize_t xone_dongle_pairing_show(struct device *dev,
+										struct device_attribute *attr,
+										char *buf)
+{
+	struct usb_interface *intf = to_usb_interface(dev);
+	struct xone_dongle *dongle = usb_get_intfdata(intf);
+
+	return sprintf(buf, "%d\n", dongle->pairing);
+}
+
+static ssize_t xone_dongle_pairing_store(struct device *dev,
+										 struct device_attribute *attr,
+										 const char *buf, size_t count)
+{
+	struct usb_interface *intf = to_usb_interface(dev);
+	struct xone_dongle *dongle = usb_get_intfdata(intf);
+	bool enable;
+	int err;
+
+	err = kstrtobool(buf, &enable);
+	if (err)
+		return err;
+
+	err = pm_runtime_resume_and_get(dev);
+	if (err)
+		return err;
+
+	err = xone_dongle_toggle_pairing(dongle, enable);
+	if (err)
+		return err;
+
+	pm_runtime_put(dev);
+
+	return count;
+}
+
+static struct device_attribute xone_dongle_attr_pairing =
+	__ATTR(pairing, 0644,
+	       xone_dongle_pairing_show,
+	       xone_dongle_pairing_store);
+
+static struct attribute *xone_dongle_attrs[] = {
+	&xone_dongle_attr_pairing.attr,
+	NULL,
+};
+ATTRIBUTE_GROUPS(xone_dongle);
 
 static struct xone_dongle_client *
 xone_dongle_create_client(struct xone_dongle *dongle, u8 *addr)
@@ -942,6 +990,10 @@ static int xone_dongle_probe(struct usb_interface *intf,
 
 	usb_set_intfdata(intf, dongle);
 
+	err = device_add_groups(&intf->dev, xone_dongle_groups);
+	if (err)
+		goto err_destroy_dongle;
+
 	/* enable USB remote wakeup and autosuspend */
 	intf->needs_remote_wakeup = true;
 	device_wakeup_enable(&dongle->mt.udev->dev);
@@ -950,12 +1002,19 @@ static int xone_dongle_probe(struct usb_interface *intf,
 	usb_enable_autosuspend(dongle->mt.udev);
 
 	return 0;
+
+err_destroy_dongle:
+	xone_dongle_destroy(dongle);
+
+	return err;
 }
 
 static void xone_dongle_disconnect(struct usb_interface *intf)
 {
 	struct xone_dongle *dongle = usb_get_intfdata(intf);
 	int err;
+
+	device_remove_groups(&intf->dev, xone_dongle_groups);
 
 	/* can fail during USB device removal */
 	err = xone_dongle_power_off_clients(dongle);


### PR DESCRIPTION
For devices, which - much like my Surface Book Pro 2 - have an integrated Xbox Dongle, there is no hardware button for enabling the pairing mode.

For such devices, the `pairing` attribute is required for the dongle to be functional.

Changes made in this PR re-enable the `pairing` attribute based on commit 304da811e94081156376a8e10ff5eee5876c6e41.