### PR TITLE
Remove PowerA from wired id table

### DIFF
--- a/transport/wired.c
+++ b/transport/wired.c
@@ -550,7 +550,6 @@ static const struct usb_device_id xone_wired_id_table[] = {
 	{ XONE_WIRED_VENDOR(0x0e6f) }, /* PDP */
 	{ XONE_WIRED_VENDOR(0x0f0d) }, /* Hori */
 	{ XONE_WIRED_VENDOR(0x1532) }, /* Razer */
-	{ XONE_WIRED_VENDOR(0x24c6) }, /* PowerA */
 	{ XONE_WIRED_VENDOR(0x20d6) }, /* BDA */
 	{ XONE_WIRED_VENDOR(0x044f) }, /* Thrustmaster */
 	{ XONE_WIRED_VENDOR(0x10f5) }, /* Turtle Beach */


### PR DESCRIPTION
Most of Power A controllers seem to be already in kernel https://github.com/torvalds/linux/blob/master/drivers/input/joystick/xpad.c

I have PowerA Xbox Enhanced Wired Controller and it works just fine without xone installed, but when xone is installed it does not work continuously emitting `gip_handle_pkt_identify: already identified` to dmesg.

I built proposed change and it seems to solve the issue. Two original wireless One and X/S controllers connected via dongle continued working fine.

Mabye the same can be achieved with removing it from default config allowing users to enable it if necessary. I'm open to advice.