### PR TITLE
Add ASUS vendor ID

### DIFF
--- a/transport/wired.c
+++ b/transport/wired.c
@@ -562,6 +562,7 @@ static const struct usb_device_id xone_wired_id_table[] = {
 	{ XONE_WIRED_VENDOR(0x11c1) }, /* ??? */
 	{ XONE_WIRED_VENDOR(0x294b) }, /* Snakebyte */
 	{ XONE_WIRED_VENDOR(0x2c16) }, /* Priferential */
+	{ XONE_WIRED_VENDOR(0x0b05) }, /* ASUS */
 	{ },
 };
 


### PR DESCRIPTION
This adds support for the [ASUS ROG Raikiri](https://rog.asus.com/controllers/rog-raikiri-model/), has been tested by someone on the discord.