### PR TITLE
Fix incorrect method type in bus.c

### DIFF
--- a/bus/bus.c
+++ b/bus/bus.c
@@ -112,11 +112,11 @@ static void gip_bus_remove(struct device *dev)
 }
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0)
-static int gip_bus_remove_compat(struct device *dev)
+static void gip_bus_remove_compat(struct device *dev)
 {
 	gip_bus_remove(dev);
 
-	return 0;
+	return;
 }
 #endif
 


### PR DESCRIPTION
When attempting to compile on Rocky 9 I was getting "error: initialization of ‘void (*)(struct device *)’ from incompatible pointer type ‘int" errors. Switching the function signature to void to bypass the errors.

In [bus.h](https://github.com/droghio/xone/blob/379f62fe75be4cc56fee22a907c71aa329b98af7/bus/bus.h#L110) the type is defined as void so updating the compat version of the method to match.