### PR TITLE
Mitigate NULL dereference in memcpy

### DIFF
--- a/bus/protocol.c
+++ b/bus/protocol.c
@@ -379,6 +379,9 @@ static int gip_send_pkt(struct gip_client *client,
 	if (err)
 		return err;
 
+	if (!data)
+		return -EINVAL;
+
 	memcpy(client->chunk_buf_in->data, data, hdr->chunk_offset);
 
 	return 0;


### PR DESCRIPTION
Call stack  ..-> gip_dispatch_pkt() -> gip_handle_pkt_announce() -> gip_request_identification()->gip_send_pkt(client, &hdr, NULL) leads to NULL dereference in memcpy function. Quite sure, it can't really happen in real life, but compiler spams an error:

```
bus/protocol.c:382:9: error: argument 2 null where non-null expected [-Werror=nonnull]
  382 |         memcpy(client->chunk_buf_in->data, data, hdr->chunk_offset);
```

This NULL check will calm down a compiler.