### PR TITLE
Handling of 0x20d6 xbox one X/S wired gamepads (avoid bursts and depletion of urbs)

### DIFF
--- a/bus/protocol.h
+++ b/bus/protocol.h
@@ -30,6 +30,8 @@ enum gip_power_mode {
 	GIP_PWR_ON = 0x00,
 	GIP_PWR_SLEEP = 0x01,
 	GIP_PWR_OFF = 0x04,
+  GIP_PWR_RUMBLE = 0x05,
+  GIP_PWR_PAIRING = 0x06,
 	GIP_PWR_RESET = 0x07,
 };
 
@@ -98,6 +100,7 @@ struct gip_classes {
 struct gip_client;
 struct gip_adapter;
 
+int gip_set_power_mode_pairing(struct gip_client *client);
 int gip_set_power_mode(struct gip_client *client, enum gip_power_mode mode);
 int gip_send_authenticate(struct gip_client *client, void *pkt, u32 len,
 			  bool acknowledge);

--- a/transport/wired.c
+++ b/transport/wired.c
@@ -12,7 +12,7 @@
 #define XONE_WIRED_INTF_DATA 0
 #define XONE_WIRED_INTF_AUDIO 1
 
-#define XONE_WIRED_NUM_DATA_URBS 8
+#define XONE_WIRED_NUM_DATA_URBS 12
 #define XONE_WIRED_NUM_AUDIO_URBS 12
 #define XONE_WIRED_NUM_AUDIO_PKTS 8
 
@@ -80,7 +80,7 @@ static void xone_wired_complete_data_in(struct urb *urb)
 resubmit:
 	/* can fail during USB device removal */
 	err = usb_submit_urb(urb, GFP_ATOMIC);
-	if (err)
+  if (err)
 		dev_dbg(dev, "%s: submit failed: %d\n", __func__, err);
 }
 


### PR DESCRIPTION
Gamepad of brand "under control" remains stuck at first auth handshake. Some occurences of urb depletions due to interrupt out bursts.
Proposal:
- Delaying dev/input creation after completion of auth handshake
- Adding automatic acq urb when authenticating at the end of a chunk (some gamepads do not ask for ack but actually needs it to transmit next auth packet)

This PR is not top quality as it still include some delayed work with fixed delays that should ideally be replaced by triggering each transmission stage based on the interrupt out acknowledgement packet from the gamepad (routing protocol.c completion routines to gamepad.c, I guess) but this implies some future planning.

I've noticed that this kind of behavior was already implemented in the dongle.c implementation, maybe some merging is to be done to keep consistency between wired & dongle implementations.

At least, this PR works. Further improvement can be built on this.

Tested with a native Microsoft XBOX One controller for regressions. Seems fine.