### PR TITLE
fix: build on kernel v6.11

### DIFF
--- a/bus/bus.c
+++ b/bus/bus.c
@@ -56,7 +56,11 @@ static struct device_type gip_client_type = {
 	.release = gip_client_release,
 };
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 static int gip_bus_match(struct device *dev, struct device_driver *driver)
+#else
+static int gip_bus_match(struct device *dev, const struct device_driver *driver)
+#endif
 {
 	struct gip_client *client;
 	struct gip_driver *drv;


### PR DESCRIPTION
Fixes the build issue:
```text
/var/lib/dkms/xone/0.3.r57.g29ec357/build/bus/bus.c:126:18: error: initialization of ‘int (*)(struct device *, const struct device_driver *)’ from incompatible pointer type ‘int (*)(struct device *, struct device_driver *)’ [-Wincompatible-pointer-types]
  126 |         .match = gip_bus_match,
      |                  ^~~~~~~~~~~~~
/var/lib/dkms/xone/0.3.r57.g29ec357/build/bus/bus.c:126:18: note: (near initialization for ‘gip_bus_type.match’)
```

Tested and built on torvalds/linux/v6.11-rc1