### PR TITLE
Add a Vendor ID for Logitech Astro headphones

### DIFF
--- a/transport/wired.c
+++ b/transport/wired.c
@@ -563,6 +563,7 @@ static const struct usb_device_id xone_wired_id_table[] = {
 	{ XONE_WIRED_VENDOR(0x294b) }, /* Snakebyte */
 	{ XONE_WIRED_VENDOR(0x2c16) }, /* Priferential */
 	{ XONE_WIRED_VENDOR(0x0b05) }, /* ASUS */
+	{ XONE_WIRED_VENDOR(0x046d) }, /* Logitech Astro */
 	{ },
 };
 


### PR DESCRIPTION
I picked up a set of Astro A50x headphones to use with my main PC and my work laptop. To get it working, I've got my work laptop plugged into the Xbox port of the base station, however the xone drivers don't pick it up without this Vendor ID. I don't know if Logitech would use a different Vendor ID for any other Xbox hardware they do/might make, so I've just commented it as Logitech Astro in-case it's a Vendor ID for that specific sub-brand