### PR TITLE
fix lockup caused by bug in auth

### DIFF
--- a/auth/auth.h
+++ b/auth/auth.h
@@ -41,6 +41,7 @@ struct gip_auth {
 	u8 pubkey_client[GIP_AUTH_PUBKEY_LEN];
 	u8 pubkey_client2[GIP_AUTH2_PUBKEY_LEN];
 
+	u8 pms[GIP_AUTH_SECRET_LEN];
 	u8 master_secret[GIP_AUTH_SECRET_LEN];
 };
 


### PR DESCRIPTION
The pms buffer would trigger a BUG() when passed to sg_init_one() because virt_addr_valid() returns false for stack addresses (if built with CONFIG_VMAP_STACK=y). Fix it by allocating the buffer with kmalloc() like it was before.

Fixes: 87f538ca0c31 ("Move buffer allocation from auth to crypto")