### PR TITLE
fix: build on kernel v6.12

### DIFF
--- a/bus/bus.c
+++ b/bus/bus.c
@@ -56,7 +56,11 @@ static struct device_type gip_client_type = {
 	.release = gip_client_release,
 };
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0)
 static int gip_bus_match(struct device *dev, struct device_driver *driver)
+#else
+static int gip_bus_match(struct device *dev, const struct device_driver *driver)
+#endif
 {
 	struct gip_client *client;
 	struct gip_driver *drv;

--- a/driver/headset.c
+++ b/driver/headset.c
@@ -5,6 +5,7 @@
 
 #include <linux/module.h>
 #include <linux/hrtimer.h>
+#include <linux/vmalloc.h>
 #include <sound/core.h>
 #include <sound/initval.h>
 #include <sound/pcm.h>
@@ -90,13 +91,34 @@ static int gip_headset_pcm_close(struct snd_pcm_substream *sub)
 static int gip_headset_pcm_hw_params(struct snd_pcm_substream *sub,
 				     struct snd_pcm_hw_params *params)
 {
-	return snd_pcm_lib_alloc_vmalloc_buffer(sub,
-						params_buffer_bytes(params));
+	struct snd_pcm_runtime *runtime = sub->runtime;
+	size_t size = params_buffer_bytes(params);
+
+	if (runtime->dma_area) {
+		if (runtime->dma_bytes >= size)
+			return 0; /* Already large enough */
+		vfree(runtime->dma_area);
+	}
+	runtime->dma_area = vzalloc(size);
+	if (!runtime->dma_area)
+		return -ENOMEM;
+	runtime->dma_bytes = size;
+	return 1;
 }
 
 static int gip_headset_pcm_hw_free(struct snd_pcm_substream *sub)
 {
-	return snd_pcm_lib_free_vmalloc_buffer(sub);
+	struct snd_pcm_runtime *runtime = sub->runtime;
+
+	vfree(runtime->dma_area);
+	runtime->dma_area = NULL;
+	return 0;
+}
+
+static struct page *gip_headset_pcm_get_page(struct snd_pcm_substream *sub,
+                                             unsigned long offset)
+{
+	return vmalloc_to_page(sub->runtime->dma_area + offset);
 }
 
 static int gip_headset_pcm_prepare(struct snd_pcm_substream *sub)
@@ -157,7 +179,7 @@ static const struct snd_pcm_ops gip_headset_pcm_ops = {
 	.prepare = gip_headset_pcm_prepare,
 	.trigger = gip_headset_pcm_trigger,
 	.pointer = gip_headset_pcm_pointer,
-	.page = snd_pcm_lib_get_vmalloc_page,
+	.page = gip_headset_pcm_get_page,
 };
 
 static bool gip_headset_advance_pointer(struct gip_headset_stream *stream,


### PR DESCRIPTION
Fixes the build issues related to: 
```C
snd_pcm_lib_alloc_vmalloc_buffer()
snd_pcm_lib_free_vmalloc_buffer()
snd_pcm_lib_get_vmalloc_page()
```
On kernel v6.12-rc1

The change for the helper can be found at ["Drop of obsoloted vmalloc PCM buffer helper API"](https://lore.kernel.org/all/20240807152725.18948-3-tiwai@suse.de/) and the code that I implemented here was taken from the driver [here](https://lore.kernel.org/all/20240807152725.18948-2-tiwai@suse.de/)

This also depends on the PR https://github.com/medusalix/xone/pull/48 for the v6.11 build fix.

Note: I don't have a headset to verify that the driver is working as expected, I only made the necessary changes to get it to build!
