### PR TITLE
Issuing a build warning if the user has secure boot enabled but…

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ If `xone` is not being loaded automatically you might have to reboot your system
 - `Direct firmware load for xow_dongle.bin failed with error -2`
     - Download the firmware for the wireless dongle (see installation guide).
 
+- `Warning: you have secure boot enabled but don't have a signing key in the default location`
+    - verify that mok_signing_key and mok_certificate in /etc/dkms/framework.conf point to enrolled keys.  If there are none that you are aware of, you must enroll the ones that were generated as part of the build process (`mokutil --import /var/lib/dkms/mok.pub` as described here: https://github.com/dell/dkms#secure-boot ).  NB: if you are new to the process, it is STRONGLY recommended you add a --timeout -1 parameter to the mokutil command in case you need time to review the instructions upon rebooting.  Also, be warned that the enrollment program will fail if your chosen password is typed differently on QWERTY.
+
 ### Input issues
 
 You can use `evtest` and `fftest` to check the input and force feedback functionality of your devices.

--- a/install.sh
+++ b/install.sh
@@ -22,6 +22,10 @@ if [ -f /usr/local/bin/xow ]; then
     exit 1
 fi
 
+if ! [ -f /var/lib/dkms/mok.key ]; then
+    (mokutil --sb-state 2>/dev/null | grep enabled) && echo "Warning: you have secure boot enabled but don't have a signing key in the default location" >&2
+fi
+
 if [ -n "${SUDO_USER:-}" ]; then
     # Run as normal user to prevent "unsafe repository" error
     version=$(sudo -u "$SUDO_USER" git describe --tags 2> /dev/null || echo unknown)


### PR DESCRIPTION
Thanks for your fantastic software!  I did not think the dongle would EVER be supported.  Great to finally feel like it's no longer necessary to recommend the 360 dongle after all these years.

Your use of dkms is perfect, but the way that the software will silently create new self-signed keys can be a bit of a gotcha to someone using secure boot (eg, https://www.reddit.com/r/linux_gaming/comments/1as5tos/xone_doesnt_work/).  It's beyond the scope of this project to dive deep on security, but it is IMHO appropriate to at least offer some breadcrumbs. 

To that end, I have added a build warning for the case that a user has secure boot enabled but doesn't yet have keys in the default locations (eg, someone coming from akmods).  I've also added a small blurb to the troubleshooting section of the README giving an overview of what this might mean and what to do.  I believe these changes could be invaluable to novice and intermediate users until such time as your wonderful package becomes canonized by distros or the kernel itself.

Cheers!