### PR TITLE
Fix incompatible pointer type in bus.c

### DIFF
--- a/bus/bus.c
+++ b/bus/bus.c
@@ -56,7 +56,7 @@ static struct device_type gip_client_type = {
 	.release = gip_client_release,
 };
 
-static int gip_bus_match(struct device *dev, struct device_driver *driver)
+static int gip_bus_match(struct device *dev, const struct device_driver *driver)
 {
 	struct gip_client *client;
 	struct gip_driver *drv;


### PR DESCRIPTION
There is some system info:

```SH
uname -a
Linux fedora 6.11.7-300.fc41.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Nov  8 19:23:10 UTC 2024 x86_64 GNU/Linux
```

Compiler not happy when installing on my Fedora 41 (tested on master and mainline branches):

```SH
Installing xone v0.3-58-g3f00689...

Sign command: /lib/modules/6.11.7-300.fc41.x86_64/build/scripts/sign-file
Signing key: /var/lib/dkms/mok.key
Public certificate (MOK): /var/lib/dkms/mok.pub
Creating symlink /var/lib/dkms/xone/v0.3-58-g3f00689/source -> /usr/src/xone-v0.3-58-g3f00689

Cleaning build area... done.
Building module(s)...(bad exit status: 2)
Failed command:
make -j8 KERNELRELEASE=6.11.7-300.fc41.x86_64 -C /lib/modules/6.11.7-300.fc41.x86_64/build M=/var/lib/dkms/xone/v0.3-58-g3f00689/build
Error! Bad return status for module build on kernel: 6.11.7-300.fc41.x86_64 (x86_64)
Consult /var/lib/dkms/xone/v0.3-58-g3f00689/build/make.log for more information.
DKMS make.log for xone-v0.3-58-g3f00689 for kernel 6.11.7-300.fc41.x86_64 (x86_64)
Fri 15 Nov 2024 09:05:01 PM EST
make: Entering directory '/usr/src/kernels/6.11.7-300.fc41.x86_64'
  CC [M]  /var/lib/dkms/xone/v0.3-58-g3f00689/build/transport/wired.o
  CC [M]  /var/lib/dkms/xone/v0.3-58-g3f00689/build/transport/dongle.o
  CC [M]  /var/lib/dkms/xone/v0.3-58-g3f00689/build/transport/mt76.o
  CC [M]  /var/lib/dkms/xone/v0.3-58-g3f00689/build/bus/bus.o
  CC [M]  /var/lib/dkms/xone/v0.3-58-g3f00689/build/bus/protocol.o
  CC [M]  /var/lib/dkms/xone/v0.3-58-g3f00689/build/auth/auth.o
  CC [M]  /var/lib/dkms/xone/v0.3-58-g3f00689/build/auth/crypto.o
  CC [M]  /var/lib/dkms/xone/v0.3-58-g3f00689/build/driver/common.o
/var/lib/dkms/xone/v0.3-58-g3f00689/build/bus/bus.c:111:18: error: initialization of ‘int (*)(struct device *, const struct device_driver *)’ from incompatible pointer type ‘int (*)(struct device *, struct device_driver *)’ [-Wincompatible-pointer-types]
  111 |         .match = gip_bus_match,
      |                  ^~~~~~~~~~~~~
/var/lib/dkms/xone/v0.3-58-g3f00689/build/bus/bus.c:111:18: note: (near initialization for ‘gip_bus_type.match’)
make[2]: *** [scripts/Makefile.build:244: /var/lib/dkms/xone/v0.3-58-g3f00689/build/bus/bus.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [/usr/src/kernels/6.11.7-300.fc41.x86_64/Makefile:1966: /var/lib/dkms/xone/v0.3-58-g3f00689/build] Error 2
make: *** [Makefile:236: __sub-make] Error 2
make: Leaving directory '/usr/src/kernels/6.11.7-300.fc41.x86_64'
```

Simple fix make compiler happy, installation now working, xbox one controller also now working, me happy:

```SH
➜  fix-bus-invalid-cast git:(fix-bus-incompatible-pointer) sudo ./install.sh
Installing xone v0.3-58-g1689d1b...

Sign command: /lib/modules/6.11.7-300.fc41.x86_64/build/scripts/sign-file
Signing key: /var/lib/dkms/mok.key
Public certificate (MOK): /var/lib/dkms/mok.pub
Creating symlink /var/lib/dkms/xone/v0.3-58-g1689d1b/source -> /usr/src/xone-v0.3-58-g1689d1b

Cleaning build area... done.
Building module(s).... done.
Signing module /var/lib/dkms/xone/v0.3-58-g1689d1b/build/xone-wired.ko
Signing module /var/lib/dkms/xone/v0.3-58-g1689d1b/build/xone-dongle.ko
Signing module /var/lib/dkms/xone/v0.3-58-g1689d1b/build/xone-gip.ko
Signing module /var/lib/dkms/xone/v0.3-58-g1689d1b/build/xone-gip-gamepad.ko
Signing module /var/lib/dkms/xone/v0.3-58-g1689d1b/build/xone-gip-headset.ko
Signing module /var/lib/dkms/xone/v0.3-58-g1689d1b/build/xone-gip-chatpad.ko
Signing module /var/lib/dkms/xone/v0.3-58-g1689d1b/build/xone-gip-madcatz-strat.ko
Signing module /var/lib/dkms/xone/v0.3-58-g1689d1b/build/xone-gip-madcatz-glam.ko
Signing module /var/lib/dkms/xone/v0.3-58-g1689d1b/build/xone-gip-pdp-jaguar.ko
Cleaning build area... done.

Installing /lib/modules/6.11.7-300.fc41.x86_64/extra/xone-wired.ko.xz
Installing /lib/modules/6.11.7-300.fc41.x86_64/extra/xone-dongle.ko.xz
Installing /lib/modules/6.11.7-300.fc41.x86_64/extra/xone-gip.ko.xz
Installing /lib/modules/6.11.7-300.fc41.x86_64/extra/xone-gip-gamepad.ko.xz
Installing /lib/modules/6.11.7-300.fc41.x86_64/extra/xone-gip-headset.ko.xz
Installing /lib/modules/6.11.7-300.fc41.x86_64/extra/xone-gip-chatpad.ko.xz
Installing /lib/modules/6.11.7-300.fc41.x86_64/extra/xone-gip-madcatz-strat.ko.xz
Installing /lib/modules/6.11.7-300.fc41.x86_64/extra/xone-gip-madcatz-glam.ko.xz
Installing /lib/modules/6.11.7-300.fc41.x86_64/extra/xone-gip-pdp-jaguar.ko.xz
Running depmod.... done.
```