### PR TITLE
Fix type on gip_bus_match to const

### DIFF
--- a/bus/bus.c
+++ b/bus/bus.c
@@ -56,7 +56,7 @@ static struct device_type gip_client_type = {
 	.release = gip_client_release,
 };
 
-static int gip_bus_match(struct device *dev, struct device_driver *driver)
+static int gip_bus_match(struct device *dev, const struct device_driver *driver)
 {
 	struct gip_client *client;
 	struct gip_driver *drv;


### PR DESCRIPTION
When compiling DKMS module I get:
Failed command:
make -j32 KERNELRELEASE=6.11.8-300.fc41.x86_64 -C /lib/modules/6.11.8-300.fc41.x86_64/build M=/var/lib/dkms/xone/v0.3-57-g29ec357/build Error! Bad return status for module build on kernel: 6.11.8-300.fc41.x86_64 (x86_64) Consult /var/lib/dkms/xone/v0.3-57-g29ec357/build/make.log for more information. DKMS make.log for xone-v0.3-57-g29ec357 for kernel 6.11.8-300.fc41.x86_64 (x86_64) vie 29 nov 2024 00:07:37 -03
make: Entering directory '/usr/src/kernels/6.11.8-300.fc41.x86_64'
  CC [M]  /var/lib/dkms/xone/v0.3-57-g29ec357/build/transport/wired.o
  CC [M]  /var/lib/dkms/xone/v0.3-57-g29ec357/build/transport/dongle.o
  CC [M]  /var/lib/dkms/xone/v0.3-57-g29ec357/build/transport/mt76.o
  CC [M]  /var/lib/dkms/xone/v0.3-57-g29ec357/build/bus/bus.o
  CC [M]  /var/lib/dkms/xone/v0.3-57-g29ec357/build/bus/protocol.o
  CC [M]  /var/lib/dkms/xone/v0.3-57-g29ec357/build/auth/auth.o
  CC [M]  /var/lib/dkms/xone/v0.3-57-g29ec357/build/auth/crypto.o
  CC [M]  /var/lib/dkms/xone/v0.3-57-g29ec357/build/driver/common.o
  CC [M]  /var/lib/dkms/xone/v0.3-57-g29ec357/build/driver/gamepad.o
  CC [M]  /var/lib/dkms/xone/v0.3-57-g29ec357/build/driver/headset.o
  CC [M]  /var/lib/dkms/xone/v0.3-57-g29ec357/build/driver/chatpad.o
  CC [M]  /var/lib/dkms/xone/v0.3-57-g29ec357/build/driver/madcatz_strat.o
  CC [M]  /var/lib/dkms/xone/v0.3-57-g29ec357/build/driver/madcatz_glam.o
  CC [M]  /var/lib/dkms/xone/v0.3-57-g29ec357/build/driver/pdp_jaguar.o
  LD [M]  /var/lib/dkms/xone/v0.3-57-g29ec357/build/xone-gip-madcatz-glam.o
  LD [M]  /var/lib/dkms/xone/v0.3-57-g29ec357/build/xone-gip-gamepad.o
  LD [M]  /var/lib/dkms/xone/v0.3-57-g29ec357/build/xone-gip-pdp-jaguar.o
/var/lib/dkms/xone/v0.3-57-g29ec357/build/bus/bus.c:126:18: error: initialization of ‘int (*)(struct device *, const struct device_driver *)’ from incompatible pointer type ‘int (*)(struct device *, struct device_driver *)’ [-Wincompatible-pointer-types]
  126 |         .match = gip_bus_match,
      |                  ^~~~~~~~~~~~~
/var/lib/dkms/xone/v0.3-57-g29ec357/build/bus/bus.c:126:18: note: (near initialization for ‘gip_bus_type.match’)
make[2]: *** [scripts/Makefile.build:244: /var/lib/dkms/xone/v0.3-57-g29ec357/build/bus/bus.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [/usr/src/kernels/6.11.8-300.fc41.x86_64/Makefile:1966: /var/lib/dkms/xone/v0.3-57-g29ec357/build] Error 2
make: *** [Makefile:236: __sub-make] Error 2
make: Leaving directory '/usr/src/kernels/6.11.8-300.fc41.x86_64'

The provided log details the process and failure of building a kernel module using DKMS (Dynamic Kernel Module Support). Initially, the build area is cleaned successfully, and the build process begins with the command `make -j32 KERNELRELEASE=6.11.8-300.fc41.x86_64 -C build M=/var/lib/dkms/xone/v0.3-57-g29ec357/build`. However, the build process exits with a status of 2, indicating an error.

The log suggests consulting the `make.log` file for more information. The `make.log` file shows the detailed compilation steps, where multiple source files are compiled into object files. The compilation process involves various components of the module, such as transport, bus, auth, and driver files.

The critical error occurs in the file `bus.c` at line 126, where there is a type mismatch during the initialization of a function pointer. Specifically, the function pointer `gip_bus_match` is being assigned to `gip_bus_type.match`, but their types are incompatible. The expected type is `int (*)(struct device *, const struct device_driver *)`, but the provided type is `int (*)(struct device *, struct device_driver *)`. This type mismatch causes the compilation to fail.

As a result of this error, the build process is halted, and subsequent steps are not completed. The `make` command exits with errors, and the directory 6.11.8-300.fc41.x86_64 is left without a successful build.