### PR TITLE
Do a proper install check

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@ if ! [ -x "$(command -v dkms)" ]; then
     exit 1
 fi
 
-if [ -n "$(dkms status xone)" ]; then
+if [ -n "$(dkms status|grep xone)" ]; then
     echo 'Driver is already installed!' >&2
     exit 1
 fi


### PR DESCRIPTION
The check for xone being installed will fail, if users have some other modules installed via dkms. For example xpad.

This will make sure that we only check for xone being added to dkms.