### PR TITLE
Modified bus.c to fix error message on install

### DIFF
--- a/bus/bus.c
+++ b/bus/bus.c
@@ -56,7 +56,7 @@ static struct device_type gip_client_type = {
 	.release = gip_client_release,
 };
 
-static int gip_bus_match(struct device *dev, struct device_driver *driver)
+static int gip_bus_match(struct device *dev, const struct device_driver *driver)
 {
 	struct gip_client *client;
 	struct gip_driver *drv;


### PR DESCRIPTION
## Xbox Controller Driver Compatibility Report - GAMESIR G7 SE (USB)

### System Information

*   **OS:** Ubuntu 22.04 LTS
*   **Kernel:** 5.15.0-xx-generic
*   **Driver Version:** Xone 0.3

### Newly Built Modules

The following modules have to be built again:

*   xone-dongle.ko
*   xone-gip-chatpad.ko
*   xone-gip-gamepad.ko
*   xone-gip-headset.ko
*   xone-gip-madcatz.ko
*   xone-gip-pdp.ko
*   xone-wired.ko

with the changes in `bus.c`


### Device Information

*   **Controller Model:** GAMESIR G7 SE Xbox One Controller
*   **Connection Method:** USB

### Potential Issues

Encountered errors during installation.

#### Install Logs

````text
Installing xone v0.3-57-g29ec357...
Sign command: /usr/bin/kmodsign
Signing key: /var/lib/shim-signed/mok/MOK.priv
Public certificate (MOK): /var/lib/shim-signed/mok/MOK.der
Creating symlink /var/lib/dkms/xone/v0.3-57-g29ec357/source -> /usr/src/xone-v0.3-57-g29ec357

Building module:
Cleaning build area...
make -j12 KERNELRELEASE=6.11.0-21-generic -C /lib/modules/6.11.0-21-generic/build M=/var/lib/dkms/xone/v0.3-57-g29ec357/build...(bad exit status: 2)
ERROR (dkms apport): binary package for xone: v0.3-57-g29ec357 not found
Error! Bad return status for module build on kernel: 6.11.0-21-generic (x86_64)
Consult /var/lib/dkms/xone/v0.3-57-g29ec357/build/make.log for more information.
````

#### DKMS make.log

````text
Wed Apr  2 03:34:00 PM -03 2025
make: Entering directory '/usr/src/linux-headers-6.11.0-21-generic'
warning: the compiler differs from the one used to build the kernel
  The kernel was built by: x86_64-linux-gnu-gcc-13 (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
  You are using:           gcc-13 (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
  CC [M]  /var/lib/dkms/xone/v0.3-57-g29ec357/build/transport/wired.o
  CC [M]  /var/lib/dkms/xone/v0.3-57-g29ec357/build/transport/dongle.o
  CC [M]  /var/lib/dkms/xone/v0.3-57-g29ec357/build/transport/mt76.o
  CC [M]  /var/lib/dkms/xone/v0.3-57-g29ec357/build/bus/bus.o
  CC [M]  /var/lib/dkms/xone/v0.3-57-g29ec357/build/bus/protocol.o
  CC [M]  /var/lib/dkms/xone/v0.3-57-g29ec357/build/auth/auth.o
  CC [M]  /var/lib/dkms/xone/v0.3-57-g29ec357/build/auth/crypto.o
  CC [M]  /var/lib/dkms/xone/v0.3-57-g29ec357/build/driver/common.o
  CC [M]  /var/lib/dkms/xone/v0.3-57-g29ec357/build/driver/gamepad.o
  CC [M]  /var/lib/dkms/xone/v0.3-57-g29ec357/build/driver/headset.o
  CC [M]  /var/lib/dkms/xone/v0.3-57-g29ec357/build/driver/chatpad.o
  CC [M]  /var/lib/dkms/xone/v0.3-57-g29ec357/build/driver/madcatz_strat.o
/var/lib/dkms/xone/v0.3-57-g29ec357/build/bus/bus.c:126:18: error: initialization of ‘int (*)(struct device *, const struct device_driver *)’ from incompatible pointer type ‘int (*)(struct device *, struct device_driver *)’ [-Werror=incompatible-pointer-types]
  126 |         .match = gip_bus_match,
      |                  ^~~~~~~~~~~~~
/var/lib/dkms/xone/v0.3-57-g29ec357/build/bus/bus.c:126:18: note: (near initialization for ‘gip_bus_type.match’)
  CC [M]  /var/lib/dkms/xone/v0.3-57-g29ec357/build/driver/madcatz_glam.o
  CC [M]  /var/lib/dkms/xone/v0.3-57-g29ec357/build/driver/pdp_jaguar.o
cc1: some warnings being treated as errors
make[2]: *** [scripts/Makefile.build:244: /var/lib/dkms/xone/v0.3-57-g29ec357/build/bus/bus.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [/usr/src/linux-headers-6.11.0-21-generic/Makefile:1932: /var/lib/dkms/xone/v0.3-57-g29ec357/build] Error 2
make: *** [Makefile:224: __sub-make] Error 2
make: Leaving directory '/usr/src/linux-headers-6.11.0-21-generic'
````

#### Other Symptoms

The controller is not recognized by the system or any other applications.

### Steps to Reproduce

1.  Clone the repository: `git clone https://github.com/medusalix/xone`
2.  Navigate to the xone directory: `cd xone`
3.  Run the installation script: `sudo ./install.sh`

I've also disabled secure boot to see if dkms isn't working properly (the error still occurs with or without secure boot).

### Expected Behavior

The controller should be recognized by the system and other applications.

### Additional Information

*   Did you try the solutions in [troubleshooting.md#module-loading](troubleshooting.md#module-loading)? No
*   Additional context or configuration details:
    *   I changed the `bus.c` file:
        *   Added: `const` qualifier to the `device_driver` parameter in `gip_bus_match`
        *   Removed: non-const `device_driver` parameter in `gip_bus_match`

### xone Driver Project - Linux kernel driver for Xbox accessories