### PR TITLE
Update gip_bus_match function signature for Linux Kernal 6.13.0 or above and add kernel version check

### DIFF
--- a/bus/bus.c
+++ b/bus/bus.c
@@ -56,7 +56,7 @@ static struct device_type gip_client_type = {
 	.release = gip_client_release,
 };
 
-static int gip_bus_match(struct device *dev, struct device_driver *driver)
+static int gip_bus_match(struct device *dev, const struct device_driver *driver)
 {
 	struct gip_client *client;
 	struct gip_driver *drv;


### PR DESCRIPTION
… in gip_headset_pcm_hw_params and gip_headset_pcm_hw_free functions

- Changed the parameter type of gip_bus_match to const struct device_driver * for better const-correctness.
- Added conditional compilation for buffer allocation and freeing in gip_headset_pcm_hw_params and gip_headset_pcm_hw_free to handle changes in kernel version 6.13.0 and above.