### PR TITLE
Add 8BitDo vendor ID

### DIFF
--- a/transport/wired.c
+++ b/transport/wired.c
@@ -563,6 +563,7 @@ static const struct usb_device_id xone_wired_id_table[] = {
 	{ XONE_WIRED_VENDOR(0x294b) }, /* Snakebyte */
 	{ XONE_WIRED_VENDOR(0x2c16) }, /* Priferential */
 	{ XONE_WIRED_VENDOR(0x0b05) }, /* ASUS */
+	{ XONE_WIRED_VENDOR(0x2dc8) }, /* 8BitDo */
 	{ },
 };
 


### PR DESCRIPTION
This adds the support for 8BitDo controllers - tested with [8BitDo ultimate controller](https://www.8bitdo.com/ultimate-bluetooth-controller/) with dongle and cable.
All default buttons working.

not supported additional buttons P1, P2, star, profile [see manual](https://download.8bitdo.com/Manual/Controller/Ultimate/Ultimate-Bluetooth-Controller.pdf)